### PR TITLE
Bump starfield 0.11 to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,9 +2432,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b93ef240e0fc643093ef80412cae570bc46a0e802f39fc65b38f4322ece9e1"
+checksum = "42042be8ac3f550a5709b25c675b5f1e77d7c2f6f0986dbfec76c8bd9dca07c3"
 dependencies = [
  "base64",
  "byteorder",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -24,7 +24,7 @@ float-cmp = "0.9"
 
 # Image processing
 image = "0.25"
-starfield = "0.11"
+starfield = "0.12"
 
 # Scientific computing
 rustfft = "6.3.0"


### PR DESCRIPTION
## Summary

- Update `starfield` dependency in `shared` from 0.11 to 0.12.1
- No source changes required

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — all 477 tests pass
- [x] `cargo clippy -- -W clippy::all` clean