### PR TITLE
Fix FITS writer to write rows in bottom-up order

### DIFF
--- a/shared/src/frame_writer.rs
+++ b/shared/src/frame_writer.rs
@@ -210,6 +210,17 @@ fn save_as_png(payload: &ImagePayload, filepath: &Path) -> Result<()> {
 }
 
 fn save_as_fits(payload: &ImagePayload, filepath: &Path) -> Result<()> {
+    // FITS conventions:
+    //   - NAXIS1 = fastest-varying axis = image columns / x.
+    //   - NAXIS2 = slower axis = image rows / y, increasing upward
+    //     (origin is the bottom-left pixel).
+    // fitsio's `ImageDescription::dimensions` is in fast-to-slow order, so
+    // we pass [width, height] = [NAXIS1, NAXIS2].
+    //
+    // ndarray Array2 is row-major top-down (row 0 is the top of the image).
+    // To preserve orientation under standard FITS readers (astropy, ds9,
+    // AstroImageJ), we flip rows so the bottom ndarray row is written first
+    // (lowest NAXIS2) and the top row is written last (highest NAXIS2).
     let (width, height, data_type) = match payload {
         ImagePayload::U16(frame) => {
             let (h, w) = frame.dim();
@@ -238,11 +249,13 @@ fn save_as_fits(payload: &ImagePayload, filepath: &Path) -> Result<()> {
 
     match payload {
         ImagePayload::U16(frame) => {
-            let data: Vec<i32> = frame.iter().map(|&v| v as i32).collect();
+            let flipped = frame.slice(ndarray::s![..;-1, ..]);
+            let data: Vec<i32> = flipped.iter().map(|&v| v as i32).collect();
             i32::write_image(&mut fptr, &hdu, &data)?;
         }
         ImagePayload::F64(frame) => {
-            let data: Vec<f64> = frame.iter().cloned().collect();
+            let flipped = frame.slice(ndarray::s![..;-1, ..]);
+            let data: Vec<f64> = flipped.iter().copied().collect();
             f64::write_image(&mut fptr, &hdu, &data)?;
         }
         _ => unreachable!(),
@@ -386,6 +399,97 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(100));
 
         assert!(filepath.exists());
+    }
+
+    /// Walk HDUs and return the first one whose NAXIS > 0 (the image HDU).
+    /// fitsio's `create_image` emits a NAXIS=0 primary stub before the
+    /// image extension, so callers should not assume HDU 0 holds the data.
+    #[cfg(test)]
+    fn open_image_hdu(fptr: &fitsio::compat::fitsfile::FitsFile) -> fitsio::compat::hdu::FitsHdu {
+        let mut idx = 0;
+        loop {
+            let hdu = fptr
+                .hdu(idx)
+                .expect("ran out of HDUs without finding image");
+            let naxis = hdu.read_key::<i64>(fptr, "NAXIS").unwrap_or(0);
+            if naxis > 0 {
+                return hdu;
+            }
+            idx += 1;
+        }
+    }
+
+    #[test]
+    fn test_save_fits_naxis_order_and_orientation_u16() {
+        use fitsio::compat::fitsfile::FitsFile;
+        use fitsio::compat::images::ReadImage;
+
+        let temp_dir = TempDir::new().unwrap();
+        let filepath = temp_dir.path().join("naxis_u16.fits");
+
+        // Non-square so a transposed write would be detectable. Place a
+        // distinctive marker at a known (row, col) in ndarray (top-down)
+        // coordinates so we can verify the on-disk FITS layout.
+        let rows = 32usize;
+        let cols = 64usize;
+        let marker_row = 0usize; // top row of the image
+        let marker_col = 10usize;
+        let marker_value: u16 = 4242;
+
+        let mut frame = Array2::<u16>::zeros((rows, cols));
+        frame[[marker_row, marker_col]] = marker_value;
+
+        save_frame(&ImagePayload::U16(frame), &filepath, FrameFormat::Fits).unwrap();
+
+        let fptr = FitsFile::open(&filepath).unwrap();
+        let hdu = open_image_hdu(&fptr);
+
+        let naxis1 = hdu.read_key::<i64>(&fptr, "NAXIS1").unwrap();
+        let naxis2 = hdu.read_key::<i64>(&fptr, "NAXIS2").unwrap();
+        assert_eq!(naxis1 as usize, cols, "NAXIS1 must be image width (cols)");
+        assert_eq!(naxis2 as usize, rows, "NAXIS2 must be image height (rows)");
+
+        // FITS storage is bottom-row-first. ndarray's top row (marker_row=0)
+        // therefore lands at NAXIS2 = rows (the last row in the buffer).
+        let buffer = i32::read_image(&fptr, &hdu).unwrap();
+        let expected_idx = (rows - 1 - marker_row) * cols + marker_col;
+        assert_eq!(buffer[expected_idx], marker_value as i32);
+        assert_eq!(
+            buffer[marker_col], 0,
+            "top of ndarray must not land at NAXIS2=1"
+        );
+    }
+
+    #[test]
+    fn test_save_fits_naxis_order_and_orientation_f64() {
+        use fitsio::compat::fitsfile::FitsFile;
+        use fitsio::compat::images::ReadImage;
+
+        let temp_dir = TempDir::new().unwrap();
+        let filepath = temp_dir.path().join("naxis_f64.fits");
+
+        let rows = 17usize;
+        let cols = 41usize;
+        let marker_row = 3usize;
+        let marker_col = 29usize;
+        let marker_value: f64 = std::f64::consts::PI;
+
+        let mut frame = Array2::<f64>::zeros((rows, cols));
+        frame[[marker_row, marker_col]] = marker_value;
+
+        save_frame(&ImagePayload::F64(frame), &filepath, FrameFormat::Fits).unwrap();
+
+        let fptr = FitsFile::open(&filepath).unwrap();
+        let hdu = open_image_hdu(&fptr);
+
+        let naxis1 = hdu.read_key::<i64>(&fptr, "NAXIS1").unwrap();
+        let naxis2 = hdu.read_key::<i64>(&fptr, "NAXIS2").unwrap();
+        assert_eq!(naxis1 as usize, cols);
+        assert_eq!(naxis2 as usize, rows);
+
+        let buffer = f64::read_image(&fptr, &hdu).unwrap();
+        let expected_idx = (rows - 1 - marker_row) * cols + marker_col;
+        assert!((buffer[expected_idx] - marker_value).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The FITS writer in `frame_writer.rs` was writing pixel rows in ndarray top-down order, but standard FITS readers (astropy, ds9, AstroImageJ) interpret `NAXIS2` as increasing upward with origin at the bottom-left. The result: every `.fits` file produced by `sensor_shootout`/`scene_runner` was displayed upside-down by stock tools, and downstream consumers had to apply a compensating vertical flip on read.
- That compensating flip introduced a 1-pixel boresight offset on even-height images. Empirical evidence reported in [focalplane#77](https://github.com/CosmicFrontierLabs/focalplane/issues/77): n=999/1000 synthetic test fields exhibited a systematic Δδ = +0.129\" ± 0.018\" — a full pixel at IMX455 plate scale — masking sub-mas-class solver precision underneath.
- This PR flips rows before writing, so ndarray row `H-1` (image bottom) lands at `NAXIS2=1` and row `0` (image top) at `NAXIS2=H`. Standard tools now display the image right-side-up and downstream consumers can drop their compensating flips.
- The existing `[width, height]` dimension order (`NAXIS1=cols, NAXIS2=rows`) was already FITS-standard and is unchanged. Issue #77's framing implied otherwise; the new tests pin down the actual contract.

## What changed

- `save_as_fits` now `.slice(s![..;-1, ..])`s the ndarray before flattening for both `u16` and `f64` payloads.
- Doc comment added to `save_as_fits` documenting the FITS axis/origin conventions and why the flip is required.

## Tests

Two new roundtrip tests use **non-square** arrays (so a transpose is detectable) with a marker at ndarray `(0, col)` — the top of the image — and verify:

1. `NAXIS1 == cols` and `NAXIS2 == rows` (axis order).
2. The marker lands at on-disk buffer index `(rows - 1 - row) * cols + col`, i.e. the topmost ndarray row maps to the highest `NAXIS2` (top of the FITS image).

Both `u16` and `f64` paths are covered.

## Test plan

- [x] `cargo test -p shared --features frame-writer --lib frame_writer` — 11/11 passing
- [x] `cargo test --workspace --all-features` — full suite green
- [x] `cargo clippy --workspace --all-features -- -W clippy::all` — clean
- [x] `cargo fmt --all`

## Downstream follow-ups

After this lands and is pinned in `focalplane/Cargo.toml`, downstream consumers (e.g. `zodiacal/src/main.rs:304-313`) should remove their compensating `arr.slice(s![..;-1, ..])`. With the writer right-side-up, the +0.129\" Dec systematic disappears.

Closes CosmicFrontierLabs/focalplane#77 from the producer side.