### PR TITLE
noise: parallelise read-noise pass

### DIFF
--- a/shared/src/image_proc/noise/generate.rs
+++ b/shared/src/image_proc/noise/generate.rs
@@ -181,6 +181,56 @@ pub fn generate_noise_with_precomputed_params(
     }
 }
 
+/// Add zero-mean Gaussian read noise to an electron image in parallel.
+///
+/// Read noise is the electronics-domain noise of a CCD/CMOS sensor — Johnson
+/// noise in the source-follower, kTC reset noise, ADC quantisation. Unlike
+/// Poisson shot noise it is *additive*, signal-independent, and well modelled
+/// by a zero-mean Gaussian with a per-pixel RMS in electrons. After sampling
+/// we clamp negatives to zero, since downstream consumers (quantisers, FITS
+/// writers, downstream Poisson-resampling) treat the array as an
+/// electron count.
+///
+/// Implementation mirrors [`apply_poisson_photon_noise`]: the image is split
+/// into `chunk_size` row blocks, each block gets a deterministic per-chunk
+/// `StdRng` derived from the base seed, and the Gaussian draws happen inside
+/// rayon's parallel iterator. This pattern keeps the output bit-identical
+/// for a given seed regardless of thread count.
+///
+/// # Arguments
+/// * `electron_image` - 2D array containing pre-read-noise electron counts per pixel
+/// * `read_noise_rms` - RMS of the per-pixel Gaussian, in electrons. `0.0`
+///   short-circuits and returns the input unchanged.
+/// * `rng_seed` - Optional seed for the per-chunk RNGs
+///
+/// # Returns
+/// * An `ndarray::Array2<f64>` with read noise added, clamped at zero
+pub fn apply_gaussian_read_noise(
+    electron_image: &Array2<f64>,
+    read_noise_rms: f64,
+    rng_seed: Option<u64>,
+) -> Array2<f64> {
+    // Zero RMS is a no-op — skip the chunked pass to save the f64 clone +
+    // rayon dispatch on every render.
+    if read_noise_rms <= 0.0 {
+        return electron_image.clone();
+    }
+    let seed = rng_seed.unwrap_or(rng().next_u64());
+    let normal =
+        Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be finite and >= 0");
+
+    process_array_in_parallel_chunks(
+        electron_image.clone(),
+        seed,
+        Some(64), // Match apply_poisson_photon_noise: 64 rows per chunk.
+        |chunk_view, rng| {
+            chunk_view.iter_mut().for_each(|pixel| {
+                *pixel = (*pixel + normal.sample(rng)).max(0.0);
+            });
+        },
+    )
+}
+
 /// Apply Poisson arrival time statistics to star photon image in parallel
 ///
 /// This function takes a mean electron image (star flux) and applies Poisson noise
@@ -268,5 +318,56 @@ mod tests {
                 assert_eq!(noise1[[i, j]], noise2[[i, j]]);
             }
         }
+    }
+
+    #[test]
+    fn apply_gaussian_read_noise_recovers_target_rms() {
+        // A large flat image with a known pedestal: after adding RMS=8 e-
+        // Gaussian noise, the empirical std should land near 8.
+        let pedestal = 500.0_f64;
+        let rms = 8.0_f64;
+        let image = Array2::from_elem((200, 200), pedestal);
+        let noisy = apply_gaussian_read_noise(&image, rms, Some(7));
+
+        let mean_actual = noisy.mean().unwrap();
+        let std_actual = noisy.std(0.0);
+        assert_relative_eq!(mean_actual, pedestal, epsilon = 0.5);
+        assert_relative_eq!(std_actual, rms, epsilon = 0.3);
+    }
+
+    #[test]
+    fn apply_gaussian_read_noise_is_deterministic_for_seed() {
+        // Same seed => bit-identical output (regardless of thread count).
+        let image = Array2::from_elem((64, 64), 100.0);
+        let a = apply_gaussian_read_noise(&image, 5.0, Some(42));
+        let b = apply_gaussian_read_noise(&image, 5.0, Some(42));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn apply_gaussian_read_noise_zero_rms_is_identity() {
+        // RMS=0 short-circuits to a clone — every pixel unchanged.
+        let image = Array2::from_elem((16, 16), 42.0);
+        let out = apply_gaussian_read_noise(&image, 0.0, Some(0));
+        assert_eq!(image, out);
+    }
+
+    #[test]
+    fn apply_gaussian_read_noise_clamps_at_zero() {
+        // A zero-pedestal image with a large RMS will see negative draws on
+        // ~half the pixels; the clamp must drop them to exactly 0.0.
+        let image = Array2::from_elem((128, 128), 0.0);
+        let out = apply_gaussian_read_noise(&image, 5.0, Some(11));
+        let min = out.iter().cloned().fold(f64::INFINITY, f64::min);
+        assert!(min >= 0.0, "expected non-negative output, got min = {min}");
+        // At zero pedestal and RMS=5, about half of draws would be negative;
+        // after clamping the empirical mean is RMS/sqrt(2π) ≈ 2.0 e-, much
+        // larger than any plausible numerical drift.
+        let mean_actual = out.mean().unwrap();
+        assert_relative_eq!(
+            mean_actual,
+            5.0 / (2.0 * std::f64::consts::PI).sqrt(),
+            epsilon = 0.25
+        );
     }
 }

--- a/shared/src/image_proc/noise/mod.rs
+++ b/shared/src/image_proc/noise/mod.rs
@@ -9,6 +9,7 @@ pub mod quantify;
 
 // Re-export commonly used functions for backward compatibility
 pub use generate::{
-    apply_poisson_photon_noise, generate_noise_with_precomputed_params, simple_normal_array,
+    apply_gaussian_read_noise, apply_poisson_photon_noise, generate_noise_with_precomputed_params,
+    simple_normal_array,
 };
 pub use quantify::estimate_noise_level;


### PR DESCRIPTION
## Summary

- Adds `apply_gaussian_read_noise` next to `apply_poisson_photon_noise`, using the same chunked-rayon pattern (`process_array_in_parallel_chunks`, 64-row blocks, per-chunk seeded `StdRng`).
- Output is bit-identical for a given seed regardless of thread count.
- Negatives are clamped to `0.0` so downstream consumers (quantisers, FITS writers, Poisson-resamplers) still see an electron count.
- Zero-RMS short-circuits to a clone so a no-noise tile pays nothing extra.

## Motivation

While profiling the focalplane motion simulator on a 61 MP IMX455 tile, the single-threaded `mapv`-based read-noise pass in `simulator/src/sims/motion_blur.rs` was ~1.49 s/tile — about 3× slower than the parallel Poisson stage (~430 ms). After swapping the focalplane code to call `apply_gaussian_read_noise` (separate PR), the read-noise phase drops to ~386 ms, matching the Poisson stage and removing the asymmetry between the two noise passes.

## Test plan

- [x] `cargo test --lib --quiet apply_gaussian_read_noise` — 4 new tests cover RMS recovery, determinism for a given seed, RMS=0 identity, and zero-clamping behaviour
- [x] `cargo test --lib --quiet image_proc::noise` — full noise module suite still green (18 tests)
- [x] `cargo clippy --all-targets -- -W clippy::all` — no new warnings introduced