### PR TITLE
noise: take input by value to drop the 488 MB clone

### DIFF
--- a/shared/src/image_proc/noise/generate.rs
+++ b/shared/src/image_proc/noise/generate.rs
@@ -199,7 +199,9 @@ pub fn generate_noise_with_precomputed_params(
 /// output bit-identical for a given seed regardless of thread count.
 ///
 /// # Arguments
-/// * `electron_image` - 2D array containing pre-read-noise electron counts per pixel
+/// * `electron_image` - 2D array containing pre-read-noise electron counts
+///   per pixel. Consumed by this function; if the caller still needs the
+///   pre-noise version they must clone it explicitly before the call.
 /// * `read_noise_rms` - RMS of the per-pixel Gaussian, in electrons. `0.0`
 ///   short-circuits and returns the input unchanged.
 /// * `rng_seed` - Optional seed for the per-chunk RNGs
@@ -207,21 +209,20 @@ pub fn generate_noise_with_precomputed_params(
 /// # Returns
 /// * An `ndarray::Array2<f64>` with read noise added, clamped at zero
 pub fn apply_gaussian_read_noise(
-    electron_image: &Array2<f64>,
+    electron_image: Array2<f64>,
     read_noise_rms: f64,
     rng_seed: Option<u64>,
 ) -> Array2<f64> {
-    // Zero RMS is a no-op — skip the chunked pass to save the f64 clone +
-    // rayon dispatch on every render.
+    // Zero RMS is a no-op — return the input unchanged. No allocation.
     if read_noise_rms <= 0.0 {
-        return electron_image.clone();
+        return electron_image;
     }
     let seed = rng_seed.unwrap_or(rng().next_u64());
     let normal =
         Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be finite and >= 0");
 
     process_array_in_parallel_chunks(
-        electron_image.clone(),
+        electron_image,
         seed,
         Some(64), // Match apply_poisson_photon_noise: 64 rows per chunk.
         |chunk_view, rng| {
@@ -239,24 +240,22 @@ pub fn apply_gaussian_read_noise(
 /// as the mean of a Poisson distribution.
 ///
 /// # Arguments
-/// * `mean_electron_image` - 2D array containing mean electron counts per pixel
+/// * `mean_electron_image` - 2D array containing mean electron counts per
+///   pixel. Consumed by this function; if the caller still needs the
+///   pre-noise version they must clone it explicitly before the call.
 /// * `rng_seed` - Optional seed for random number generator
 ///
 /// # Returns
 /// * An `ndarray::Array2<f64>` with Poisson-sampled electron counts
 pub fn apply_poisson_photon_noise(
-    mean_electron_image: &Array2<f64>,
+    mean_electron_image: Array2<f64>,
     rng_seed: Option<u64>,
 ) -> Array2<f64> {
-    let (_height, _width) = mean_electron_image.dim();
     let seed = rng_seed.unwrap_or(rng().next_u64());
-
-    // Clone the input array to get the same shape
-    let poisson_image = mean_electron_image.clone();
 
     // Process the array in parallel chunks with our helper function
     process_array_in_parallel_chunks(
-        poisson_image,
+        mean_electron_image,
         seed,
         Some(64), // Process 64 rows at a time
         |chunk_view, rng| {
@@ -328,7 +327,7 @@ mod tests {
         let pedestal = 500.0_f64;
         let rms = 8.0_f64;
         let image = Array2::from_elem((200, 200), pedestal);
-        let noisy = apply_gaussian_read_noise(&image, rms, Some(7));
+        let noisy = apply_gaussian_read_noise(image, rms, Some(7));
 
         let mean_actual = noisy.mean().unwrap();
         let std_actual = noisy.std(0.0);
@@ -340,17 +339,18 @@ mod tests {
     fn apply_gaussian_read_noise_is_deterministic_for_seed() {
         // Same seed => bit-identical output (regardless of thread count).
         let image = Array2::from_elem((64, 64), 100.0);
-        let a = apply_gaussian_read_noise(&image, 5.0, Some(42));
-        let b = apply_gaussian_read_noise(&image, 5.0, Some(42));
+        let a = apply_gaussian_read_noise(image.clone(), 5.0, Some(42));
+        let b = apply_gaussian_read_noise(image, 5.0, Some(42));
         assert_eq!(a, b);
     }
 
     #[test]
     fn apply_gaussian_read_noise_zero_rms_is_identity() {
-        // RMS=0 short-circuits to a clone — every pixel unchanged.
+        // RMS=0 short-circuits — every pixel unchanged.
         let image = Array2::from_elem((16, 16), 42.0);
-        let out = apply_gaussian_read_noise(&image, 0.0, Some(0));
-        assert_eq!(image, out);
+        let expected = image.clone();
+        let out = apply_gaussian_read_noise(image, 0.0, Some(0));
+        assert_eq!(expected, out);
     }
 
     #[test]
@@ -358,7 +358,7 @@ mod tests {
         // A zero-pedestal image with a large RMS will see negative draws on
         // ~half the pixels; the clamp must drop them to exactly 0.0.
         let image = Array2::from_elem((128, 128), 0.0);
-        let out = apply_gaussian_read_noise(&image, 5.0, Some(11));
+        let out = apply_gaussian_read_noise(image, 5.0, Some(11));
         let min = out.iter().cloned().fold(f64::INFINITY, f64::min);
         assert!(min >= 0.0, "expected non-negative output, got min = {min}");
         // At zero pedestal and RMS=5, about half of draws would be negative;


### PR DESCRIPTION
Stacked on #13. Once that lands, this PR's base will auto-rebase onto main.

## Summary

`apply_poisson_photon_noise` and `apply_gaussian_read_noise` now take the input `Array2<f64>` by value instead of by reference. The internal `clone()` that previously matched the `&Array2` input is gone — the caller hands over ownership, the function mutates and returns it.

```diff
- pub fn apply_poisson_photon_noise(mean_electron_image: &Array2<f64>, ...) -> Array2<f64>
+ pub fn apply_poisson_photon_noise(mean_electron_image: Array2<f64>, ...) -> Array2<f64>

- pub fn apply_gaussian_read_noise(electron_image: &Array2<f64>, ...) -> Array2<f64>
+ pub fn apply_gaussian_read_noise(electron_image: Array2<f64>, ...) -> Array2<f64>
```

## Why this is safe

All known callers (focalplane `motion_blur.rs` and `image_proc/render.rs`, 4 call sites total) build a single-use temporary `Array2<f64>` and pass it as `&temp` purely to satisfy the old API, then never touch the temp again. The clone inside was pure waste — ~100 ms / 488 MB of memcpy on a 61 MP IMX455 frame, every tile.

If a caller someday genuinely needs the input afterwards, they can pay an explicit `.clone()` at the call site — visible, opt-in, not hidden inside the API.

## Measured impact

61 MP `Array2<f64>` (9576 × 6388), aarch64, 5-core release build, microbench in `focalplane/simulator/examples/noise_throughput.rs`:

| case | before | after | Δ |
|---|---:|---:|---:|
| `apply_gaussian_read_noise` (RMS=2.5) | 198 ms | **31 ms** | **-84%** |
| `apply_poisson_photon_noise` (mean=500, normal approx) | 202 ms | **32 ms** | **-84%** |
| `apply_poisson_photon_noise` (mean=5, real Poisson) | 250 ms | **72 ms** | **-71%** |

After this change the production parallel paths match the **DIY ceiling** (SmallRng + StandardNormal in raw rayon chunks at 26 ms / 2.4 GP/s) to within ~20%. The noise stage stops being a meaningful per-frame cost.

## Tests

All four `apply_gaussian_read_noise` tests updated to pass owned arrays. The determinism test now does an explicit `image.clone()` before the second call — the only test that genuinely needs to reuse the input. Statistical + determinism checks unchanged; all 18 noise tests pass.

## Caller migration

Focalplane is the only known consumer. Migration is mechanical — drop the `&`:

```diff
- apply_poisson_photon_noise(&mean_image, ...)
+ apply_poisson_photon_noise(mean_image, ...)
```

I'll open the focalplane follow-up PR (4 call sites + dep rev bump) once this lands.