### PR TITLE
units: enable uom serde feature (closes #16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1530,6 +1531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1578,6 +1580,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2900,7 +2903,11 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
 dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-rational",
  "num-traits",
+ "serde",
  "typenum",
 ]
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -51,7 +51,7 @@ tiny-skia = "0.11"
 usvg = "0.45.0"
 
 # Units
-uom = "0.37.0"
+uom = { version = "0.37.0", features = ["serde"] }
 serde_json = "1.0.145"
 crossbeam-channel = "0.5.15"
 anyhow = "1.0.100"

--- a/shared/src/units.rs
+++ b/shared/src/units.rs
@@ -444,6 +444,37 @@ mod tests {
         assert!(airy_disk < fov);
     }
 
+    /// `uom`'s `serde` feature emits each quantity as a bare `f64` in its SI
+    /// base unit. Downstream JSON schemas should treat the serialized values
+    /// accordingly:
+    ///   - `Length` / `Wavelength` → meters
+    ///   - `Temperature` → kelvin (not celsius — the `*_celsius` helpers are
+    ///     presentation only)
+    ///   - `Area` → square meters
+    ///   - `Angle` → radians (not degrees)
+    #[test]
+    fn test_serde_roundtrip_si_base_units() {
+        let len = Length::from_meters(1.5);
+        let temp = Temperature::from_celsius(20.0);
+        let area = Area::from_square_meters(2.0);
+        let ang = Angle::from_degrees(45.0);
+
+        assert_eq!(serde_json::to_string(&len).unwrap(), "1.5");
+        assert_eq!(serde_json::to_string(&temp).unwrap(), "293.15");
+        assert_eq!(serde_json::to_string(&area).unwrap(), "2.0");
+        assert_eq!(serde_json::to_string(&ang).unwrap(), "0.7853981633974483");
+
+        let len_back: Length = serde_json::from_str("1.5").unwrap();
+        let temp_back: Temperature = serde_json::from_str("293.15").unwrap();
+        let area_back: Area = serde_json::from_str("2.0").unwrap();
+        let ang_back: Angle = serde_json::from_str("0.7853981633974483").unwrap();
+
+        assert_relative_eq!(len_back.as_meters(), 1.5, epsilon = 1e-12);
+        assert_relative_eq!(temp_back.as_celsius(), 20.0, epsilon = 1e-10);
+        assert_relative_eq!(area_back.as_square_meters(), 2.0, epsilon = 1e-12);
+        assert_relative_eq!(ang_back.as_degrees(), 45.0, epsilon = 1e-12);
+    }
+
     #[test]
     fn test_angular_precision_limits() {
         // Test very small angles (sub-milliarcsecond precision)


### PR DESCRIPTION
Fixes #16

## Summary

- Enables the `serde` feature on `uom` in `shared/Cargo.toml`
- `Length`, `Wavelength`, `Temperature`, `Area`, `Angle` now `Serialize` / `Deserialize` for free
- No code changes needed in `shared` — just the feature flag

## Schema verification

The issue asked us to verify `uom`'s default JSON shape before relying on it. Probed `uom 0.37.0` directly — it emits a **bare `f64` in SI base unit** (not a `{value, unit}` wrapper):

| Type          | SI unit       | Example: `from_*(20.0/45.0/1.5)` |
| ------------- | ------------- | -------------------------------- |
| `Length`      | meters        | `1.5`                            |
| `Wavelength`  | meters        | `5.5e-7` (from 550 nm)           |
| `Temperature` | kelvin        | `293.15` (from 20 °C)            |
| `Area`        | square meters | `2.0`                            |
| `Angle`       | radians       | `0.7853981633974483` (from 45°)  |

Two callouts for downstream consumers:
- `Temperature` serializes as **kelvin**, not celsius — the `from_celsius`/`as_celsius` helpers are presentation-only.
- `Angle` serializes as **radians**, not degrees — same story for `from_degrees`/`from_arcseconds`.

This is path 1 from the issue (accept uom's default). The shape is light enough that path 2 (wrap with explicit canonical-unit newtypes) doesn't seem necessary unless downstream readers complain.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (449 tests, including a new roundtrip test in `shared::units::tests::test_serde_roundtrip_si_base_units` that pins the exact serialized strings)
- [x] `cargo clippy -- -W clippy::all` clean
