### PR TITLE
serde: derive on BilinearInterpolator, AiryDisk, PixelScaledAiryDisk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,8 @@ dependencies = [
  "rand",
  "rand_distr",
  "scilib",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -1476,6 +1478,7 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
  "rayon",
+ "serde",
 ]
 
 [[package]]

--- a/meter-math/Cargo.toml
+++ b/meter-math/Cargo.toml
@@ -12,7 +12,10 @@ categories = ["science", "mathematics"]
 [dependencies]
 # Linear algebra
 nalgebra = "0.32"
-ndarray = "0.16"
+ndarray = { version = "0.16", features = ["serde"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
 
 # Utilities
 thiserror = "2.0"
@@ -23,3 +26,4 @@ scilib = "1.0.0"
 approx = "0.5"
 rand = "0.9"
 rand_distr = "0.5.1"
+serde_json = "1.0"

--- a/meter-math/src/bilinear.rs
+++ b/meter-math/src/bilinear.rs
@@ -4,6 +4,7 @@
 //! 2D grids, with support for invalid data handling and configurable boundary behavior.
 
 use ndarray::Array2;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Error types for bilinear interpolation operations.
@@ -65,7 +66,14 @@ impl std::error::Error for InterpolationError {}
 /// - Irregular grid spacing (binary search for coordinates)
 /// - Invalid data handling (e.g., infinite values)
 /// - Configurable boundary behavior
-#[derive(Debug, Clone)]
+///
+/// # Serde invariant bypass
+///
+/// `Deserialize` reconstructs the fields directly and does **not** re-run the
+/// sorted-coords / matching-dimensions checks enforced by [`Self::new`]. Trust
+/// the deserialized form only when it originates from a serializer running
+/// against a value that was itself built via `new`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BilinearInterpolator {
     /// X-axis coordinates (must be sorted in ascending order)
     x_coords: Vec<f64>,
@@ -367,6 +375,27 @@ mod tests {
         assert_eq!(interp.y_coords(), y_coords.as_slice());
         assert_eq!(interp.data(), &data);
         assert!(interp.allow_extrapolation());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_preserves_interpolation() {
+        let interp = create_simple_grid().with_extrapolation(true);
+
+        let json = serde_json::to_string(&interp).unwrap();
+        let restored: BilinearInterpolator = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.x_coords(), interp.x_coords());
+        assert_eq!(restored.y_coords(), interp.y_coords());
+        assert_eq!(restored.data(), interp.data());
+        assert_eq!(restored.allow_extrapolation(), interp.allow_extrapolation());
+
+        for (x, y) in [(0.0, 0.0), (0.5, 0.5), (1.5, 0.7), (-0.3, 2.4)] {
+            assert_relative_eq!(
+                restored.interpolate(x, y).unwrap(),
+                interp.interpolate(x, y).unwrap(),
+                epsilon = 1e-12,
+            );
+        }
     }
 
     #[test]

--- a/shared/src/image_proc/airy.rs
+++ b/shared/src/image_proc/airy.rs
@@ -43,6 +43,7 @@
 
 use once_cell::sync::Lazy;
 use scilib::math::bessel;
+use serde::{Deserialize, Serialize};
 
 use crate::units::Wavelength;
 
@@ -81,7 +82,7 @@ const BESSEL_J1_FIRST_ZERO_APPROX: f64 = 3.83;
 /// - Gaussian approximation: ~10x faster, <5% error within FWHM
 /// - Triangle approximation: ~50x faster, good for rough estimates
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct AiryDisk {
     /// First zero location (first dark ring radius) in normalized units
     pub first_zero: f64,
@@ -373,7 +374,7 @@ pub static AIRY_DISK: Lazy<AiryDisk> = Lazy::new(AiryDisk::new);
 /// - Physical Airy radius = 1.22 × λ × f / D
 /// - Scale factor = physical_radius / normalized_radius
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PixelScaledAiryDisk {
     disk: AiryDisk,
     radius_scale: f64,
@@ -724,6 +725,31 @@ mod tests {
         // Central region should capture significant fraction of PSF
         assert!(fraction > 0.8); // At least 80% in central region
         assert!(fraction <= 1.0); // Can't exceed 100%
+    }
+
+    #[test]
+    fn test_airy_disk_serde_roundtrip() {
+        let disk = AiryDisk::new();
+        let json = serde_json::to_string(&disk).unwrap();
+        let restored: AiryDisk = serde_json::from_str(&json).unwrap();
+        assert_relative_eq!(restored.first_zero, disk.first_zero, epsilon = 1e-15);
+        assert_relative_eq!(restored.fwhm, disk.fwhm, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_pixel_scaled_airy_disk_serde_roundtrip() {
+        let psf = PixelScaledAiryDisk::with_fwhm(2.5, Wavelength::from_nanometers(650.0));
+        let json = serde_json::to_string(&psf).unwrap();
+        let restored: PixelScaledAiryDisk = serde_json::from_str(&json).unwrap();
+
+        assert_relative_eq!(restored.fwhm(), psf.fwhm(), epsilon = 1e-12);
+        assert_relative_eq!(restored.first_zero(), psf.first_zero(), epsilon = 1e-12);
+        assert_relative_eq!(
+            restored.reference_wavelength.as_nanometers(),
+            650.0,
+            epsilon = 1e-10,
+        );
+        assert_relative_eq!(restored.intensity(1.0), psf.intensity(1.0), epsilon = 1e-12,);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #18

## Summary

Three additive derives so downstream consumers (focalplane) can drop their parallel `*Meta` wrappers and serialize these primitives directly:

- **`meter_math::bilinear::BilinearInterpolator`** — required enabling `ndarray`'s `serde` feature in `meter-math/Cargo.toml` for `Array2<f64>` round-trip. Added `serde` as a direct dep in the same crate.
- **`shared::image_proc::airy::AiryDisk`** — pure derive (two `f64` fields).
- **`shared::image_proc::airy::PixelScaledAiryDisk`** — pure derive; its `Wavelength` field already serializes via #17.

## Invariant bypass note

`BilinearInterpolator::new` enforces sorted-coord and dimension-matching invariants that `Deserialize` will not re-run. Per the issue, documenting this on the type is sufficient — JSON is assumed to come from a serializer that round-tripped a value originally built via `new`. Added that note to the type doc-comment.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (452 tests, up from 449)
  - New: `bilinear::tests::test_serde_roundtrip_preserves_interpolation` — verifies field-level equality *and* that `interpolate(...)` produces identical results at four query points after round-trip
  - New: `image_proc::airy::tests::test_airy_disk_serde_roundtrip`
  - New: `image_proc::airy::tests::test_pixel_scaled_airy_disk_serde_roundtrip` — exercises the `Wavelength` field too
- [x] `cargo clippy --workspace -- -W clippy::all` clean