### PR TITLE
read noise: don't clamp electrons at zero

### DIFF
--- a/shared/src/image_proc/noise/generate.rs
+++ b/shared/src/image_proc/noise/generate.rs
@@ -207,7 +207,13 @@ pub fn generate_noise_with_precomputed_params(
 /// * `rng_seed` - Optional seed for the per-chunk RNGs
 ///
 /// # Returns
-/// * An `ndarray::Array2<f64>` with read noise added, clamped at zero
+/// * An `ndarray::Array2<f64>` with read noise added. Output **may be
+///   negative**: read noise is a symmetric electronics term, so clamping it
+///   at zero here would discard the downward half of every excursion and
+///   collapse a near-zero background onto a single floor value (which breaks
+///   robust, median/MAD-based noise estimators downstream). The physical
+///   floor is the ADC, applied later during quantization (after any
+///   black-level pedestal), not in this electron-space stage.
 pub fn apply_gaussian_read_noise(
     electron_image: Array2<f64>,
     read_noise_rms: f64,
@@ -227,7 +233,7 @@ pub fn apply_gaussian_read_noise(
         Some(64), // Match apply_poisson_photon_noise: 64 rows per chunk.
         |chunk_view, rng| {
             chunk_view.iter_mut().for_each(|pixel| {
-                *pixel = (*pixel + normal.sample(rng)).max(0.0);
+                *pixel += normal.sample(rng);
             });
         },
     )
@@ -354,21 +360,21 @@ mod tests {
     }
 
     #[test]
-    fn apply_gaussian_read_noise_clamps_at_zero() {
-        // A zero-pedestal image with a large RMS will see negative draws on
-        // ~half the pixels; the clamp must drop them to exactly 0.0.
+    fn apply_gaussian_read_noise_preserves_negative_excursions() {
+        // Read noise is symmetric and is NOT clamped at zero — the downward
+        // half of each excursion must survive (the floor is the ADC, applied
+        // downstream in quantization). A zero-pedestal image with a large RMS
+        // sees negative draws on ~half the pixels.
         let image = Array2::from_elem((128, 128), 0.0);
         let out = apply_gaussian_read_noise(image, 5.0, Some(11));
         let min = out.iter().cloned().fold(f64::INFINITY, f64::min);
-        assert!(min >= 0.0, "expected non-negative output, got min = {min}");
-        // At zero pedestal and RMS=5, about half of draws would be negative;
-        // after clamping the empirical mean is RMS/sqrt(2π) ≈ 2.0 e-, much
-        // larger than any plausible numerical drift.
-        let mean_actual = out.mean().unwrap();
-        assert_relative_eq!(
-            mean_actual,
-            5.0 / (2.0 * std::f64::consts::PI).sqrt(),
-            epsilon = 0.25
+        assert!(
+            min < 0.0,
+            "expected negative excursions to survive, got min = {min}"
         );
+        // Unclamped, the noise is mean-zero, so the empirical mean stays ~0
+        // (not the half-normal RMS/sqrt(2π) a clamp would produce).
+        let mean_actual = out.mean().unwrap();
+        assert_relative_eq!(mean_actual, 0.0, epsilon = 0.25);
     }
 }


### PR DESCRIPTION
## Summary
`apply_gaussian_read_noise` applied `(pixel + noise).max(0.0)`, clamping the electron image to ≥ 0. This drops the **downward half of every read-noise excursion**. For a near-zero background (short exposure / dark scene) that collapses >50% of pixels onto a single floor value.

The consequence shows up in robust noise estimation: with >50% of pixels identical, `median = floor` and `MAD = median(|x − median|) = 0`. `shared::image_proc::source_snr` then returns `f64::MAX` (SNR = signal / 0). We hit exactly this validating the FGS scene-camera closed loop — ROI tracking reported `SNR = f64::MAX` on every frame even with a black-level pedestal in place.

## Why a pedestal alone didn't fix it
A constant black level added *after* this clamp is shift-invariant for MAD: the ~55% of pixels clamped to 0 just become ~55% sitting at `black_level`. MAD stays 0. The read-noise *spread* has to survive into the quantizer for the pedestal to help.

## Fix
Drop the electron-space clamp:
```rust
-  *pixel = (*pixel + normal.sample(rng)).max(0.0);
+  *pixel += normal.sample(rng);
```
Read noise is symmetric electronics noise; the physical floor is the **ADC**, already modeled downstream in `quantize_image`'s final `dn.clamp(0.0, max_dn)` (applied *after* the black-level pedestal). With a black level ≥ a few × σ_read, the noisy signal stays positive and the background keeps a non-degenerate MAD → finite SNR.

## Impact
- **Zero black level (default):** no observable change — the ADC clamp still floors the final DN at 0.
- **Large-pedestal renders:** never clamped here in the first place (e.g. the `recovers_target_rms` test at pedestal 500).
- Intermediate electron images may now be slightly negative between the read-noise and quantization stages, which is physically correct for an additive electronics-noise term.

## Test plan
- [x] Reworked `apply_gaussian_read_noise_clamps_at_zero` → `…_preserves_negative_excursions` (asserts negatives survive, mean ≈ 0)
- [x] `cargo test -p shared` — **338 passed, 0 failed**
- [x] `cargo fmt`

Complements the focalplane black-level work (sensor `black_level_dn` applied before the floor clamp in `quantize_image`).