### PR TITLE
Upgrade ndarray 0.16 → 0.17 (shared, meter-math)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -2438,9 +2438,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42042be8ac3f550a5709b25c675b5f1e77d7c2f6f0986dbfec76c8bd9dca07c3"
+checksum = "065d0a9a42dae2090524cb239a24d6805f7f3d27cb43b0f81c2f06d7dd070abd"
 dependencies = [
  "base64",
  "byteorder",

--- a/meter-math/Cargo.toml
+++ b/meter-math/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "mathematics"]
 [dependencies]
 # Linear algebra
 nalgebra = "0.32"
-ndarray = { version = "0.16", features = ["serde"] }
+ndarray = { version = "0.17", features = ["serde"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,14 +17,14 @@ system-info = []
 [dependencies]
 # Core math and arrays
 nalgebra = "0.32"
-ndarray = { version = "0.16", features = ["rayon"] }
+ndarray = { version = "0.17", features = ["rayon"] }
 num-traits = "0.2"
 num-complex = "0.4.6"
 float-cmp = "0.9"
 
 # Image processing
 image = "0.25"
-starfield = "0.12"
+starfield = "0.13"
 
 # Scientific computing
 rustfft = "6.3.0"


### PR DESCRIPTION
## Summary
Upgrades `shared` and `meter-math` to **ndarray 0.17**, unpinning downstream crates (e.g. `tracking-test-bench`) that want to unify the workspace on 0.17.

`shared` exposes `ndarray` types in its public API and interops with `starfield` at three array boundaries (`sigma_clip`, `DAOStarFinder::find_stars`, `IRAFStarFinder::find_stars`), so it could not move until `starfield` did. This rides the coordinated **`starfield` 0.13.0** release (ndarray `^0.17`).

## Changes
- `meter-math`: ndarray `0.16` → `0.17`
- `shared`: ndarray `0.16` → `0.17`, `starfield` `0.12` → `0.13`
- `Cargo.lock` updated accordingly

No source changes were required — the ndarray API was source-compatible across the bump; the only blocker was the dual-major type collision, now resolved (single `ndarray 0.17.2` in the tree).

## Verification
- `cargo build` — clean
- `cargo tree` — single ndarray, **0.17.2** only
- `cargo test` — all pass, 0 failed
- `cargo fmt` — clean
- `cargo clippy -- -W clippy::all` — no warnings

Closes #21