### PR TITLE
Narrow interpolation exports

### DIFF
--- a/shared/src/algo/mod.rs
+++ b/shared/src/algo/mod.rs
@@ -13,6 +13,6 @@ pub mod parallel;
 pub mod psd;
 
 pub use lookup_table::{LookupError, LookupTable};
-pub use misc::{dec_dms_to_deg, interp, normalize, ra_hms_to_deg, InterpError};
+pub use misc::{dec_dms_to_deg, normalize, ra_hms_to_deg};
 pub use motion::{MotionModel, XAxisSpinner, XYWobble};
 pub use parallel::process_array_in_parallel_chunks;


### PR DESCRIPTION
## Summary

- remove the redundant `interp` and `InterpError` exports from `shared::algo`
- keep interpolation available through its canonical `shared::algo::misc` module

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p shared --lib -- -W clippy::all`
- `cargo test -p shared --lib` (348 passed)
