### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: ./.github/actions/setup

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: ./.github/actions/setup

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
   format-and-clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: ./.github/actions/setup


### PR DESCRIPTION
Bumps every `actions/checkout` pin in `.github/` to `v7`, the newest major.

Closes #34

No local testing performed — CI on this PR is the validation.